### PR TITLE
Automatic language switching function

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ export const themeConfig: ThemeConfig = {
   // COLOR SETTINGS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> START
   color: {
     // default theme mode
-    mode: 'light', // light, dark
+    mode: 'light', // light, dark, auto
     light: {
       // primary color
       // used for title, hover, etc

--- a/src/i18n/browser.ts
+++ b/src/i18n/browser.ts
@@ -1,0 +1,39 @@
+import { allLocales, defaultLocale } from '@/config'
+import { langMap } from './config'
+
+/**
+ * Mapping Browser Language Codes to Site Supported Languages
+ * @param browserLang Browser language code
+ * @returns Mapped language code
+ */
+export function mapBrowserLanguage(browserLang: string): string {
+  // Normalized language code to lowercase
+  const normalizedLang = browserLang.toLowerCase()
+  
+  // Directly match the complete language code
+  if (allLocales.includes(normalizedLang)) {
+    return normalizedLang
+  }
+  
+  // Match language prefixes (e.g., 'en-US' to 'en')
+  const langPrefix = normalizedLang.split('-')[0]
+  if (allLocales.includes(langPrefix)) {
+    return langPrefix
+  }
+  
+  // Matching through language map
+  for (const [locale, mappings] of Object.entries(langMap)) {
+    // Check the complete match
+    if (mappings.some(mapping => mapping.toLowerCase() === normalizedLang)) {
+      return locale
+    }
+    
+    // Check prefix match
+    if (mappings.some(mapping => mapping.toLowerCase().startsWith(langPrefix + '-'))) {
+      return locale
+    }
+  }
+  
+  // Return the default language code when no match is found
+  return defaultLocale
+}

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -4,6 +4,7 @@ import { ui } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 import { ClientRouter } from 'astro:transitions'
 import katexCSS from 'katex/dist/katex.min.css?url'
+import { langMap } from '@/i18n/config'
 
 interface Props {
   postTitle?: string
@@ -142,6 +143,86 @@ window
     document.dispatchEvent(new Event('theme-changed'))
   })
 </script>
+
+<!-- Automatic language detection and redirection -->
+<script is:inline define:vars={{ 
+  allLocales, 
+  defaultLocale, 
+  currentLang, 
+  langMap: Object.entries(langMap),
+  currentPath: Astro.url.pathname 
+}}>
+{
+  // Perform detection only on the first visit
+  if (typeof window !== 'undefined' && !sessionStorage.getItem('lang-detected')) {
+    // Set a flag to prevent duplicate detection
+    sessionStorage.setItem('lang-detected', 'true');
+    
+    // Check if the URL already includes an explicit language code
+    const hasExplicitLangCode = allLocales.some(lang => currentPath.startsWith(`/${lang}/`));
+    
+    // Language detection and redirection only if the URL does not explicitly specify a language code
+    if (!hasExplicitLangCode) {
+      // 获取浏览器语言
+      const browserLang = navigator.language || navigator.languages[0] || defaultLocale;
+      
+      // Mapping Browser Languages to Site Supported Languages
+      function mapBrowserLanguage(browserLang) {
+        const normalizedLang = browserLang.toLowerCase();
+        
+        // Direct matching
+        if (allLocales.includes(normalizedLang)) {
+          return normalizedLang;
+        }
+        
+        // Match language prefix
+        const langPrefix = normalizedLang.split('-')[0];
+        if (allLocales.includes(langPrefix)) {
+          return langPrefix;
+        }
+        
+        // Matching by language mapping table
+        for (const [locale, mappings] of langMap) {
+          if (mappings.some(mapping => mapping.toLowerCase() === normalizedLang)) {
+            return locale;
+          }
+          if (mappings.some(mapping => mapping.toLowerCase().startsWith(langPrefix + '-'))) {
+            return locale;
+          }
+        }
+        
+        return defaultLocale;
+      }
+
+      // Detecting the right language
+      const detectedLang = mapBrowserLanguage(browserLang);
+      
+      // Redirect if the detected language is different from the current page language
+      if (detectedLang !== currentLang) {
+        // Build Redirect URL
+        let redirectUrl;
+        
+        // Special Handling Homepage
+        if (currentPath === '/') {
+          redirectUrl = detectedLang === defaultLocale ? '/' : `/${detectedLang}/`;
+        } 
+        // Handle language switching
+        else if (currentLang === defaultLocale) {
+          redirectUrl = `/${detectedLang}${currentPath}`;
+        }
+        else {
+          const pathWithoutLang = currentPath.replace(/^\/[^/]+\//, '/');
+          redirectUrl = detectedLang === defaultLocale ? pathWithoutLang : `/${detectedLang}${pathWithoutLang}`;
+        }
+        
+        // Perform redirection
+        window.location.href = redirectUrl;
+      }
+    }
+  }
+}
+</script>
+
 
 <!-- Google Analytics -->
 {googleAnalyticsID && (

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -111,8 +111,11 @@ function isCurrentDark() {
   const currentTheme = localStorage.getItem('theme')
   if (currentTheme)
     return currentTheme === 'dark'
-  if (defaultMode)
-    return defaultMode === 'dark'
+  if (defaultMode === 'light')
+    return false
+  if (defaultMode === 'dark')
+    return true
+  // Auto mode or undefined, use system preference
   return window.matchMedia('(prefers-color-scheme: dark)').matches
 }
 

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -163,7 +163,7 @@ window
     
     // Language detection and redirection only if the URL does not explicitly specify a language code
     if (!hasExplicitLangCode) {
-      // 获取浏览器语言
+      // Get Browser Language
       const browserLang = navigator.language || navigator.languages[0] || defaultLocale;
       
       // Mapping Browser Languages to Site Supported Languages

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -15,7 +15,7 @@ export interface ThemeConfig {
   }
 
   color: {
-    mode: 'light' | 'dark'
+    mode: 'light' | 'dark' | 'auto'
     light: {
       primary: string
       secondary: string


### PR DESCRIPTION

📃 **Changelog**

- Add `browser.ts` to map browser language codes to the languages supported by the website
- An inline script was added to `Head.astro` to retrieve the current browser's language settings and map them to the languages supported by the website.

📝 **Notes**

1. If the detected language is different from the current page language, redirect the user to the corresponding language version 
 (When visitors directly access **links with language codes**, the system will respect the language specified in the URL and will **not redirect** based on the browser language.).

2. Use `sessionStorage` to ensure that language detection is only performed on the user's first visit, avoiding repeated detection and redirection during page navigation. 

When the user visits the website for the first time, they will be automatically redirected to the version that best matches their browser language settings.
