### PR TITLE
[Feature] Add auto language switching

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,6 +2,7 @@
 import { moreLocales, themeConfig } from '@/config'
 import { getNextGlobalLangPath, getNextSupportedLangPath } from '@/i18n/path'
 import { isPostPage, isTagPage } from '@/utils/page'
+import { getLangFromPath } from '@/i18n/lang'
 
 interface Props {
   supportedLangs: string[]
@@ -22,6 +23,9 @@ const useSupportedLangs = isPost || (isTag && supportedLangs.length > 0)
 const nextUrl = useSupportedLangs
   ? getNextSupportedLangPath(currentPath, supportedLangs) // Switch between supported languages
   : getNextGlobalLangPath(currentPath) // Switch between all languages
+
+// Get the code for the next language
+const nextLang = getLangFromPath(nextUrl)
 ---
 
 <div
@@ -35,8 +39,9 @@ const nextUrl = useSupportedLangs
   {showLanguageSwitcher && (
     <a
       href={nextUrl}
-      class="aspect-square w-4 c-secondary active:scale-90 hover:c-primary"
+      class="aspect-square w-4 c-secondary active:scale-90 hover:c-primary language-switcher"
       aria-label="Switch website language"
+      data-next-lang={nextLang}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -65,6 +70,29 @@ const nextUrl = useSupportedLangs
     </svg>
   </button>
 </div>
+
+<!-- Language Switcher Script -->
+<script>
+  import { saveUserLanguagePreference } from '@/i18n/browser';
+  
+  function setupLanguageSwitcher() {
+    const languageSwitchers = document.querySelectorAll('.language-switcher');
+    languageSwitchers.forEach((switcher) => {
+      switcher.addEventListener('click', () => {
+        // Get the next language code
+        const nextLang = switcher.getAttribute('data-next-lang');
+        if (nextLang) {
+          // Save user's manually selected language preferences
+          saveUserLanguagePreference(nextLang);
+        }
+      })
+    })
+  }
+
+  // Initialize the event listener
+  setupLanguageSwitcher();
+  document.addEventListener('astro:after-swap', setupLanguageSwitcher);
+</script>
 
 <!-- Theme Toggle Script >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> -->
 <script is:inline define:vars={{ lightMode, darkMode }}>

--- a/src/i18n/browser.ts
+++ b/src/i18n/browser.ts
@@ -1,0 +1,136 @@
+import { defaultLocale, moreLocales } from '@/config'
+import { langMap } from '@/i18n/config'
+import { buildNextLangPath } from '@/i18n/path'
+import { getLangFromPath } from '@/i18n/lang'
+
+/**
+ * Save the user's manually selected language preference to localStorage
+ * @param lang User-selected language code
+ */
+export function saveUserLanguagePreference(lang: string): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('userLanguagePreference', lang)
+  }
+}
+
+/**
+ * Get user's manually selected language preference
+ * @returns User's language preference or null
+ */
+export function getUserLanguagePreference(): string | null {
+  if (typeof localStorage !== 'undefined') {
+    return localStorage.getItem('userLanguagePreference')
+  }
+  return null
+}
+
+/**
+ * Retrieve the browser's preferred language and map it to supported languages
+ * @returns Matching support language codes
+ */
+export function getBrowserLang(): string {
+  if (typeof navigator === 'undefined') return defaultLocale
+  
+  // Get browser language settings
+  const browserLangs = navigator.languages || [navigator.language]
+  
+  // Try to directly match the supported languages
+  for (const browserLang of browserLangs) {
+    const normalizedLang = browserLang.toLowerCase()
+    if ([defaultLocale, ...moreLocales].includes(normalizedLang)) {
+      return normalizedLang
+    }
+  }
+  
+  // Try to match by langMap
+  for (const browserLang of browserLangs) {
+    const normalizedLang = browserLang.toLowerCase()
+    for (const [lang, variants] of Object.entries(langMap)) {
+      if (variants.some(variant => 
+        normalizedLang === variant.toLowerCase() ||
+        normalizedLang.startsWith(variant.toLowerCase().split('-')[0])
+      )) {
+        return lang
+      }
+    }
+  }
+  
+  return defaultLocale
+}
+
+/**
+ * Checks if the page exists in the specified language version
+ * @param currentPath Current Path
+ * @param currentLang Current language
+ * @param targetLang Target language
+ * @returns Promise<boolean> Does the page exist
+ */
+export async function checkPageExists(currentPath: string, currentLang: string, targetLang: string): Promise<boolean> {
+  const targetPath = buildNextLangPath(currentPath, currentLang, targetLang)
+  
+  try {
+    const response = await fetch(targetPath, { method: 'HEAD' })
+    return response.ok
+  } catch (e) {
+    return false
+  }
+}
+
+/**
+ * Try to automatically redirect to the appropriate language version
+ * @param currentPath Current path
+ * @param currentLang Current Language
+ */
+export async function autoRedirectByLang(currentPath: string, currentLang: string): Promise<void> {
+  // Check if there has been a redirection in this session to prevent circular redirections
+  const redirectionKey = `redirected_${window.location.pathname}`;
+  if (sessionStorage.getItem(redirectionKey)) {
+    return;
+  }
+  
+  // URLs with language codes, respecting user preferences
+  if (currentLang !== defaultLocale && currentPath.startsWith(`/${currentLang}/`)) {
+    return;
+  }
+  
+  // Firstly, check if the user has manually set language preferences
+  const userPreference = getUserLanguagePreference();
+  
+  // If there is a user preference for a language that differs from the current one, 
+  // prioritize redirecting to the user's preferred language.
+  if (userPreference && userPreference !== currentLang) {
+    if (await checkPageExists(currentPath, currentLang, userPreference)) {
+      // Mark this path as redirected to prevent loops
+      sessionStorage.setItem(redirectionKey, 'true');
+      const targetPath = buildNextLangPath(currentPath, currentLang, userPreference);
+      window.location.href = targetPath;
+      return;
+    }
+  }
+  
+  // Get the browser language
+  const browserLang = getBrowserLang();
+  
+  // If the browser language matches the current language, no redirection is needed.
+  if (browserLang === currentLang) {
+    return;
+  }
+  
+  // Build a language priority list
+  const langPriority = [
+    browserLang, 
+    defaultLocale,
+    ...moreLocales.filter(lang => lang !== browserLang && lang !== defaultLocale)
+  ];
+  
+  // Attempt redirection by priority
+  for (const lang of langPriority) {
+    if (await checkPageExists(currentPath, currentLang, lang)) {
+      // Mark this path as redirected to prevent loops
+      sessionStorage.setItem(redirectionKey, 'true');
+      const targetPath = buildNextLangPath(currentPath, currentLang, lang);
+      window.location.href = targetPath;
+      break;
+    }
+  }
+}

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -99,6 +99,14 @@ const pageImage = postSlug
 <!-- Global View Transition -->
 <ClientRouter fallback="none" />
 
+<!-- Language Auto Redirect -->
+<script>
+  import { autoRedirectByLang } from '@/i18n/browser';
+  document.addEventListener('DOMContentLoaded', async () => {
+    await autoRedirectByLang(window.location.pathname, '${currentLang}');
+  });
+</script>
+
 <!-- Theme Toggle -->
 <script
   is:inline


### PR DESCRIPTION
## 📃 **Changelog**

- Add a `browser.ts` file to store the functions for the automatic language switching feature
- An inline script was added to `Head.astro` to retrieve the current browser's language settings and map them to the languages supported by the website.
- Adjust some functions in `Button.astro` to implement the feature of storing user language preference settings

## 📝 **Notes**

1. When visitors directly access **links with language codes**, the system will **respect the language specified in the URL** and **will not redirect** based on the browser language.
2. When accessing a link, if the detected browser language is different from the language of the current page, and there is a page corresponding to the browser language, redirect the user to the corresponding language version.
3. If the request fails or the page does not exist, it will fall back to the **default language version** globally defined in the config.
4. If the **default language version still does not exist**, it will match the list in `moreLocales` in sequence to accessable pages (because articles that generally do not have a default language version are usually single-language articles).
5. If the user is not satisfied with the automatically adjusted language results and chooses to **manually switch languages**, then it will be **cached**, with the **user's settings taking priority as the first choice**.
