### PR TITLE
fix: BackButton 组件返回存在问题

### DIFF
--- a/src/components/Widgets/BackButton.astro
+++ b/src/components/Widgets/BackButton.astro
@@ -20,7 +20,6 @@ import GoBackIcon from '@/assets/icons/go-back.svg'
 import { navigate } from 'astro:transitions/client'
 import { defaultLocale } from '@/config'
 import { getLangFromPath } from '@/i18n/lang'
-import { buildNextLangPath } from '@/i18n/path'
 
 function setupBackButton() {
   document.getElementById('back-button')?.addEventListener('click', () => {
@@ -32,25 +31,13 @@ function setupBackButton() {
     if (typeof getRouteHistory === 'function') {
       const history = getRouteHistory() as string[]
 
-      // Find the previous different page and convert to current language
+      // Simply find the previous different page
       let targetPath = null
       for (let i = history.length - 2; i >= 0; i--) {
         const historyPath = history[i]
         if (historyPath !== currentPath) {
-          // Adjust target path to current language
-          const targetLang = getLangFromPath(historyPath)
-          let adjustedPath = historyPath
-
-          if (targetLang !== currentLang) {
-            // Convert target path to current language
-            adjustedPath = buildNextLangPath(historyPath, targetLang, currentLang)
-          }
-
-          // Make sure the adjusted path is different from current path
-          if (adjustedPath !== currentPath) {
-            targetPath = adjustedPath
-            break
-          }
+          targetPath = historyPath
+          break
         }
       }
 

--- a/src/components/Widgets/BackButton.astro
+++ b/src/components/Widgets/BackButton.astro
@@ -1,5 +1,6 @@
 ---
-import GoBackIcon from '@/assets/icons/go-back.svg';
+import GoBackIcon from '@/assets/icons/go-back.svg'
+
 ---
 
 <button
@@ -16,17 +17,63 @@ import GoBackIcon from '@/assets/icons/go-back.svg';
 
 <!-- Go Back Script >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> -->
 <script>
-document.addEventListener('click', (e) => {
-  if (e.target instanceof Element && e.target.closest('#back-button')) {
-    // Navigate back if history exists
-    if (window.history.length > 1) {
-      window.history.back()
-      return
+import { navigate } from 'astro:transitions/client'
+import { defaultLocale } from '@/config'
+import { getLangFromPath } from '@/i18n/lang'
+
+function setupBackButton() {
+  document.getElementById('back-button')?.addEventListener('click', () => {
+    const currentPath = window.location.pathname
+    const currentLang = getLangFromPath(currentPath)
+
+    // Get the previous different page path from the global routing history
+    const getRouteHistory = window.getRouteHistory
+    const isSamePageDifferentLang = window.isSamePageDifferentLang
+
+    if (typeof getRouteHistory === 'function' && typeof isSamePageDifferentLang === 'function') {
+      const history = getRouteHistory() as string[]
+
+      // Find a previous page in the same language
+      let targetPath = null
+      for (let i = history.length - 2; i >= 0; i--) {
+        const historyPath = history[i]
+        const historyLang = getLangFromPath(historyPath)
+
+        // Only consider pages in the same language and different from current page
+        if (historyLang === currentLang && historyPath !== currentPath && !isSamePageDifferentLang(historyPath, currentPath)) {
+          targetPath = historyPath
+          break
+        }
+      }
+
+      if (targetPath) {
+        // Use Astro's navigate function to navigate to the target path, keeping the transition effect
+        navigate(targetPath)
+        return
+      }
+
+      // If no same-language target found, navigate to home page in current language
+      const homePath = currentLang === defaultLocale ? '/' : `/${currentLang}/`
+
+      // Don't navigate if already on home page
+      if (currentPath !== homePath) {
+        navigate(homePath)
+        return
+      }
     }
 
-    // Fallback to homepage
-    const siteTitleLink = document.getElementById('site-title-link')
-    siteTitleLink?.click()
-  }
-})
+    // Fallback: Use the browser's back function
+    if (window.history.length > 1) {
+      window.history.back()
+    }
+    else {
+      // Fallback to homepage
+      const siteTitleLink = document.getElementById('site-title-link')
+      siteTitleLink?.click()
+    }
+  })
+}
+
+setupBackButton()
+document.addEventListener('astro:after-swap', setupBackButton)
 </script>

--- a/src/components/Widgets/BackButton.astro
+++ b/src/components/Widgets/BackButton.astro
@@ -20,42 +20,47 @@ import GoBackIcon from '@/assets/icons/go-back.svg'
 import { navigate } from 'astro:transitions/client'
 import { defaultLocale } from '@/config'
 import { getLangFromPath } from '@/i18n/lang'
+import { buildNextLangPath } from '@/i18n/path'
 
 function setupBackButton() {
   document.getElementById('back-button')?.addEventListener('click', () => {
     const currentPath = window.location.pathname
     const currentLang = getLangFromPath(currentPath)
 
-    // Get the previous different page path from the global routing history
+    // Get the route history
     const getRouteHistory = window.getRouteHistory
-    const isSamePageDifferentLang = window.isSamePageDifferentLang
-
-    if (typeof getRouteHistory === 'function' && typeof isSamePageDifferentLang === 'function') {
+    if (typeof getRouteHistory === 'function') {
       const history = getRouteHistory() as string[]
 
-      // Find a previous page in the same language
+      // Find the previous different page and convert to current language
       let targetPath = null
       for (let i = history.length - 2; i >= 0; i--) {
         const historyPath = history[i]
-        const historyLang = getLangFromPath(historyPath)
+        if (historyPath !== currentPath) {
+          // Adjust target path to current language
+          const targetLang = getLangFromPath(historyPath)
+          let adjustedPath = historyPath
 
-        // Only consider pages in the same language and different from current page
-        if (historyLang === currentLang && historyPath !== currentPath && !isSamePageDifferentLang(historyPath, currentPath)) {
-          targetPath = historyPath
-          break
+          if (targetLang !== currentLang) {
+            // Convert target path to current language
+            adjustedPath = buildNextLangPath(historyPath, targetLang, currentLang)
+          }
+
+          // Make sure the adjusted path is different from current path
+          if (adjustedPath !== currentPath) {
+            targetPath = adjustedPath
+            break
+          }
         }
       }
 
       if (targetPath) {
-        // Use Astro's navigate function to navigate to the target path, keeping the transition effect
         navigate(targetPath)
         return
       }
 
-      // If no same-language target found, navigate to home page in current language
+      // If no target found, go to current language home page
       const homePath = currentLang === defaultLocale ? '/' : `/${currentLang}/`
-
-      // Don't navigate if already on home page
       if (currentPath !== homePath) {
         navigate(homePath)
         return

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -74,7 +74,6 @@ const ROUTE_HISTORY_KEY = 'retypeset-route-history'
 const MAX_HISTORY_LENGTH = 20
 
 function getCurrentPagePath() {
-  // 只记录 pathname，忽略 hash
   return window.location.pathname
 }
 
@@ -101,10 +100,10 @@ function addToRouteHistory(path: string) {
   const history = getRouteHistory()
   const lastPath = history[history.length - 1]
 
-  // 只在路径真正变化时记录（忽略 hash 变化）
+  // record only when the path actually changes (ignore hash changes).
   if (path !== lastPath) {
     history.push(path)
-    // 限制历史长度
+    // limit the history length
     if (history.length > MAX_HISTORY_LENGTH) {
       history.splice(0, history.length - MAX_HISTORY_LENGTH)
     }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ import GsapAnimation from '@/components/Widgets/GsapAnimation.astro'
 import MediaEmbeds from '@/components/Widgets/MediaEmbeds.astro'
 import PhotoSwipe from '@/components/Widgets/PhotoSwipe.astro'
 import SoundEffect from '@/components/Widgets/SoundEffect.astro'
-import themeConfig, { defaultLocale, moreLocales } from '@/config'
+import themeConfig from '@/config'
 
 import Head from '@/layouts/Head.astro'
 import { getPageInfo } from '@/utils/page'
@@ -68,12 +68,13 @@ const MarginBottom = isPost && themeConfig.comment?.enabled
 </html>
 
 <!-- Global Routing Tracking Script -->
-<script define:vars={{ defaultLocale, moreLocales }}>
+<script>
 // Global Routing History Management
 const ROUTE_HISTORY_KEY = 'retypeset-route-history'
 const MAX_HISTORY_LENGTH = 20
 
 function getCurrentPagePath() {
+  // 只记录 pathname，忽略 hash
   return window.location.pathname
 }
 
@@ -87,7 +88,7 @@ function getRouteHistory() {
   }
 }
 
-function saveRouteHistory(history) {
+function saveRouteHistory(history: string[]) {
   try {
     localStorage.setItem(ROUTE_HISTORY_KEY, JSON.stringify(history))
   }
@@ -96,54 +97,16 @@ function saveRouteHistory(history) {
   }
 }
 
-/**
- * Extract language-agnostic path from a route
- * Examples:
- * '/' -> '/'
- * '/en/' -> '/'
- * '/en/posts/hello/' -> '/posts/hello/'
- * '/posts/hello/' -> '/posts/hello/'
- */
-function extractBasePath(path) {
-  // Remove trailing slash for consistent comparison
-  const cleanPath = path.replace(/\/$/, '') || '/'
-
-  // Check if path starts with a supported language
-  for (const lang of moreLocales) {
-    if (cleanPath.startsWith(`/${lang}`)) {
-      const withoutLang = cleanPath.substring(`/${lang}`.length) || '/'
-      return withoutLang
-    }
-  }
-
-  return cleanPath === '' ? '/' : cleanPath
-}
-
-/**
- * Check if two paths represent the same page in different languages
- */
-function isSamePageDifferentLang(path1, path2) {
-  return extractBasePath(path1) === extractBasePath(path2)
-}
-
-function addToRouteHistory(path) {
+function addToRouteHistory(path: string) {
   const history = getRouteHistory()
   const lastPath = history[history.length - 1]
 
-  // Only record when the path actually changes
+  // 只在路径真正变化时记录（忽略 hash 变化）
   if (path !== lastPath) {
-    // Don't record if it's the same page in a different language
-    if (lastPath && isSamePageDifferentLang(path, lastPath)) {
-      // Replace the last entry with the new language version
-      history[history.length - 1] = path
-    }
-    else {
-      // Add new path to history
-      history.push(path)
-      // Limit the history length
-      if (history.length > MAX_HISTORY_LENGTH) {
-        history.splice(0, history.length - MAX_HISTORY_LENGTH)
-      }
+    history.push(path)
+    // 限制历史长度
+    if (history.length > MAX_HISTORY_LENGTH) {
+      history.splice(0, history.length - MAX_HISTORY_LENGTH)
     }
     saveRouteHistory(history)
   }
@@ -164,7 +127,6 @@ initRouteTracking()
 document.addEventListener('astro:after-swap', handleRouteChange)
 window.addEventListener('popstate', handleRouteChange)
 
-// Expose global functions for BackButton use
+// Expose global function for BackButton use
 window.getRouteHistory = getRouteHistory
-window.isSamePageDifferentLang = isSamePageDifferentLang
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,6 +69,9 @@ const MarginBottom = isPost && themeConfig.comment?.enabled
 
 <!-- Global Routing Tracking Script -->
 <script>
+import { defaultLocale, moreLocales } from '@/config'
+import { getLangFromPath } from '@/i18n/lang'
+
 // Global Routing History Management
 const ROUTE_HISTORY_KEY = 'retypeset-route-history'
 const MAX_HISTORY_LENGTH = 20
@@ -96,16 +99,75 @@ function saveRouteHistory(history: string[]) {
   }
 }
 
+/**
+ * Extract language-agnostic path from a route
+ */
+function extractBasePath(path: string) {
+  const cleanPath = path.replace(/\/$/, '') || '/'
+
+  // Remove language prefix
+  for (const lang of moreLocales) {
+    if (cleanPath.startsWith(`/${lang}`)) {
+      const withoutLang = cleanPath.substring(`/${lang}`.length) || '/'
+      return withoutLang
+    }
+  }
+
+  return cleanPath === '' ? '/' : cleanPath
+}
+
+/**
+ * Check if two paths represent the same page in different languages
+ */
+function isSamePageDifferentLang(path1: string, path2: string) {
+  return extractBasePath(path1) === extractBasePath(path2)
+}
+
+/**
+ * Convert a path to target language
+ */
+function convertPathToLang(path: string, targetLang: string) {
+  const cleanPath = path.replace(/\/$/, '') || '/'
+
+  // Remove current language prefix
+  for (const lang of moreLocales) {
+    if (cleanPath.startsWith(`/${lang}`)) {
+      const withoutLang = cleanPath.substring(`/${lang}`.length) || '/'
+      // Add target language prefix (unless it's default locale)
+      return targetLang === defaultLocale ? withoutLang : `/${targetLang}${withoutLang}`
+    }
+  }
+
+  // Current path is in default language
+  // Add target language prefix (unless target is also default)
+  return targetLang === defaultLocale ? path : `/${targetLang}${path}`
+}
+
 function addToRouteHistory(path: string) {
   const history = getRouteHistory()
   const lastPath = history[history.length - 1]
 
-  // record only when the path actually changes (ignore hash changes).
+  // Only record when the path actually changes (ignore hash changes)
   if (path !== lastPath) {
-    history.push(path)
-    // limit the history length
-    if (history.length > MAX_HISTORY_LENGTH) {
-      history.splice(0, history.length - MAX_HISTORY_LENGTH)
+    // 🔄 If same page in different language: convert entire history
+    if (lastPath && isSamePageDifferentLang(path, lastPath)) {
+      const newLang = getLangFromPath(path)
+
+      // Convert all paths in history to the new language
+      for (let i = 0; i < history.length; i++) {
+        history[i] = convertPathToLang(history[i], newLang)
+      }
+
+      // Replace the last entry with the new language version
+      history[history.length - 1] = path
+    }
+    // ➕ If different page: add new record
+    else {
+      history.push(path)
+      // Limit the history length
+      if (history.length > MAX_HISTORY_LENGTH) {
+        history.splice(0, history.length - MAX_HISTORY_LENGTH)
+      }
     }
     saveRouteHistory(history)
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,7 +9,8 @@ import GsapAnimation from '@/components/Widgets/GsapAnimation.astro'
 import MediaEmbeds from '@/components/Widgets/MediaEmbeds.astro'
 import PhotoSwipe from '@/components/Widgets/PhotoSwipe.astro'
 import SoundEffect from '@/components/Widgets/SoundEffect.astro'
-import themeConfig from '@/config'
+import themeConfig, { defaultLocale, moreLocales } from '@/config'
+
 import Head from '@/layouts/Head.astro'
 import { getPageInfo } from '@/utils/page'
 import '@/styles/extend.css'
@@ -65,3 +66,105 @@ const MarginBottom = isPost && themeConfig.comment?.enabled
     <MediaEmbeds />
   </body>
 </html>
+
+<!-- Global Routing Tracking Script -->
+<script define:vars={{ defaultLocale, moreLocales }}>
+// Global Routing History Management
+const ROUTE_HISTORY_KEY = 'retypeset-route-history'
+const MAX_HISTORY_LENGTH = 20
+
+function getCurrentPagePath() {
+  return window.location.pathname
+}
+
+function getRouteHistory() {
+  try {
+    const stored = localStorage.getItem(ROUTE_HISTORY_KEY)
+    return stored ? JSON.parse(stored) : []
+  }
+  catch {
+    return []
+  }
+}
+
+function saveRouteHistory(history) {
+  try {
+    localStorage.setItem(ROUTE_HISTORY_KEY, JSON.stringify(history))
+  }
+  catch {
+    // nothing to do
+  }
+}
+
+/**
+ * Extract language-agnostic path from a route
+ * Examples:
+ * '/' -> '/'
+ * '/en/' -> '/'
+ * '/en/posts/hello/' -> '/posts/hello/'
+ * '/posts/hello/' -> '/posts/hello/'
+ */
+function extractBasePath(path) {
+  // Remove trailing slash for consistent comparison
+  const cleanPath = path.replace(/\/$/, '') || '/'
+
+  // Check if path starts with a supported language
+  for (const lang of moreLocales) {
+    if (cleanPath.startsWith(`/${lang}`)) {
+      const withoutLang = cleanPath.substring(`/${lang}`.length) || '/'
+      return withoutLang
+    }
+  }
+
+  return cleanPath === '' ? '/' : cleanPath
+}
+
+/**
+ * Check if two paths represent the same page in different languages
+ */
+function isSamePageDifferentLang(path1, path2) {
+  return extractBasePath(path1) === extractBasePath(path2)
+}
+
+function addToRouteHistory(path) {
+  const history = getRouteHistory()
+  const lastPath = history[history.length - 1]
+
+  // Only record when the path actually changes
+  if (path !== lastPath) {
+    // Don't record if it's the same page in a different language
+    if (lastPath && isSamePageDifferentLang(path, lastPath)) {
+      // Replace the last entry with the new language version
+      history[history.length - 1] = path
+    }
+    else {
+      // Add new path to history
+      history.push(path)
+      // Limit the history length
+      if (history.length > MAX_HISTORY_LENGTH) {
+        history.splice(0, history.length - MAX_HISTORY_LENGTH)
+      }
+    }
+    saveRouteHistory(history)
+  }
+}
+
+function initRouteTracking() {
+  const currentPath = getCurrentPagePath()
+  addToRouteHistory(currentPath)
+}
+
+function handleRouteChange() {
+  const currentPath = getCurrentPagePath()
+  addToRouteHistory(currentPath)
+}
+
+// Initialize routing tracking
+initRouteTracking()
+document.addEventListener('astro:after-swap', handleRouteChange)
+window.addEventListener('popstate', handleRouteChange)
+
+// Expose global functions for BackButton use
+window.getRouteHistory = getRouteHistory
+window.isSamePageDifferentLang = isSamePageDifferentLang
+</script>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,7 +8,6 @@ declare global {
   interface Window {
     webkitAudioContext: typeof AudioContext
     getRouteHistory?: () => string[]
-    isSamePageDifferentLang?: (path1: string, path2: string) => boolean
   }
 
   interface Document {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,6 +7,8 @@ declare global {
 
   interface Window {
     webkitAudioContext: typeof AudioContext
+    getRouteHistory?: () => string[]
+    isSamePageDifferentLang?: (path1: string, path2: string) => boolean
   }
 
   interface Document {


### PR DESCRIPTION
# 🐛 Bug 修复

## 问题描述
- **问题现象**: 在文章页面通过 TOC 跳转文章具体位置后或者在文章页切换语言后点击 BackButton 不能回到正确的主页。
- **影响范围**: 文章页面
- **复现步骤**: 
  1. 在文章页面通过 TOC 组件跳转具体位置，此时路由存在 hash 路由（`/posts/xxxx` -> `/posts/xxxx#/xxxx`）。点击 BackButton，文章没有回到主页，而是回到上一个路由。（`/posts/xxxx#/xxxx` -> `/posts/xxxx`）。预期应该回到主页（index） 位置。
  2. 在文章页面点击多语言切换，例如从中文切到了日文（`/posts/xxxx` -> `/ja/posts/xxxx`），此时点击BackButton，路由只会回到 `/posts/xxxx`，而预期回到 `/ja/`

**根本原因**: 使用路由的返回进行回退，但是原生的回退不区分 hash 路由，也不考虑国际化后的路径变更问题。

## 📋 **完整逻辑流程总结**

### **第一部分：路由历史智能记录** (Layout.astro)

#### **触发时机**：
```javascript
1. initRouteTracking()                          // 页面初始化
2. document.addEventListener('astro:after-swap') // Astro 路由切换  
4. window.addEventListener('popstate')          // 浏览器前进后退
```

#### **核心记录逻辑**：
```javascript
function addToRouteHistory(path: string) {
  const history = getRouteHistory()
  const lastPath = history[history.length - 1]

  if (path !== lastPath) {  // 🎯 忽略 hash 变化
    
    // 🔄 语言切换检测
    if (lastPath && isSamePageDifferentLang(path, lastPath)) {
      const newLang = getLangFromPath(path)
      
      // ✨ 关键：转换整个历史记录到新语言
      for (let i = 0; i < history.length; i++) {
        history[i] = convertPathToLang(history[i], newLang)
      }
      history[history.length - 1] = path
    } 
    // ➕ 正常页面跳转：直接添加
    else {
      history.push(path)
    }
    
    saveRouteHistory(history)
  }
}
```

### **第二部分：智能回退逻辑** (BackButton.astro)

#### **回退流程**：
```javascript
function setupBackButton() {
  // 1️⃣ 获取当前状态
  const currentPath = window.location.pathname
  const currentLang = getLangFromPath(currentPath)
  
  // 2️⃣ 获取历史记录
  const history = getRouteHistory()
  
  // 3️⃣ 查找回退目标 (超简单逻辑)
  for (let i = history.length - 2; i >= 0; i--) {
    if (history[i] !== currentPath) {
      navigate(history[i])  // 🎯 直接跳转
      return
    }
  }
  
  // 4️⃣ 没找到目标：回到当前语言首页
  const homePath = currentLang === defaultLocale ? '/' : `/${currentLang}/`
  if (currentPath !== homePath) {
    navigate(homePath)
    return
  }
  
  // 5️⃣ 最终 fallback：浏览器原生回退
  window.history.back()
}
```

## 🎭 **关键场景流程演示**

### **场景1：Hash 路由处理**
```
用户操作: /ja/posts/hello/ → /ja/posts/hello/#section1 → /ja/posts/hello/#section2
历史记录: ['/ja/posts/hello/']  // ← hash 变化被忽略
点击回退: 找到上一个不同页面 或 回到 /ja/
```

### **场景2：语言切换处理**
```
用户操作: /es/ → /es/posts/guide/ → /ja/posts/guide/
历史变化:
  初始: ['/es/']
  跳转: ['/es/', '/es/posts/guide/']
  切换: ['/ja/', '/ja/posts/guide/']  // ← 整个历史转换到日文
点击回退: 直接跳转到 '/ja/'
```

### **场景3：正常浏览处理**
```
用户操作: /ja/ → /ja/posts/hello/ → /ja/posts/world/
历史记录: ['/ja/', '/ja/posts/hello/', '/ja/posts/world/']
点击回退: 直接跳转到 '/ja/posts/hello/'
```

## 测试验证
- [x] 本地测试通过
- [x] 手动测试验证修复效果

## 变更文件
- `src/components/Widgets/BackButton.astro`
- `src/layouts/Layout.astro`
- `src/types/global.d.ts`
