### PR TITLE
refactor: use astro built-in i18n API

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,7 +10,7 @@ import remarkDirective from 'remark-directive'
 import remarkMath from 'remark-math'
 import UnoCSS from 'unocss/astro'
 import { base, defaultLocale, themeConfig } from './src/config'
-import { langMap } from './src/i18n/config'
+import { typedLangMap } from './src/i18n/config'
 import { rehypeCodeCopyButton } from './src/plugins/rehype-code-copy-button.mjs'
 import { rehypeExternalLinks } from './src/plugins/rehype-external-links.mjs'
 import { rehypeHeadingAnchor } from './src/plugins/rehype-heading-anchor.mjs'
@@ -35,7 +35,7 @@ export default defineConfig({
   },
   ...imageConfig,
   i18n: {
-    locales: Object.entries(langMap).map(([path]) => path),
+    locales: Object.keys(typedLangMap) as (keyof typeof typedLangMap)[],
     defaultLocale,
     routing: {
       prefixDefaultLocale: themeConfig.global.prefixDefaultLocale,

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -35,11 +35,11 @@ export default defineConfig({
   },
   ...imageConfig,
   i18n: {
-    locales: Object.entries(langMap).map(([path, codes]) => ({
-      path,
-      codes: codes as [string, ...string[]],
-    })),
+    locales: Object.entries(langMap).map(([path]) => path),
     defaultLocale,
+    routing: {
+      prefixDefaultLocale: themeConfig.global.prefixDefaultLocale,
+    },
   },
   integrations: [
     UnoCSS({

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,7 +2,8 @@
 import LanguageSwitcherIcon from '@/assets/icons/language-switcher.svg'
 import ThemeToggleIcon from '@/assets/icons/theme-toggle.svg'
 import { moreLocales, themeConfig } from '@/config'
-import { getNextGlobalLangPath, getNextSupportedLangPath } from '@/i18n/path'
+import { getLangFromPath } from '@/i18n/lang'
+import { getNextLangPath } from '@/i18n/path'
 
 interface Props {
   supportedLangs: string[]
@@ -17,11 +18,11 @@ const { supportedLangs } = Astro.props
 const currentPath = Astro.url.pathname
 
 // Check if there are other languages to switch
-const showLanguageSwitcher = moreLocales.length > 0
+const showLanguageSwitcher = moreLocales.length > 0 && getLangFromPath(currentPath)
 // Choose a language switch list according to supported languages
-const nextUrl = supportedLangs.length > 0
-  ? getNextSupportedLangPath(currentPath, supportedLangs) // Use supported languages when available
-  : getNextGlobalLangPath(currentPath) // Fallback to all languages when no supported languages data
+const nextUrl = showLanguageSwitcher
+  ? getNextLangPath(currentPath, supportedLangs.length > 0 ? supportedLangs : undefined)
+  : undefined
 ---
 
 <div

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import { getRelativeLocaleUrl } from 'astro:i18n'
-import { themeConfig } from '@/config'
+import { defaultLocale, themeConfig } from '@/config'
 import { getLangFromPath } from '@/i18n/lang'
 
 const { author } = themeConfig.site
@@ -10,10 +10,10 @@ const currentYear = new Date().getFullYear()
 const year = Number(startYear) === currentYear ? startYear : `${startYear}-${currentYear}`
 
 // i18n RSS Feed Path
-const currentLang = getLangFromPath(Astro.url.pathname)
+const rssLang = getLangFromPath(Astro.url.pathname) ?? defaultLocale
 const links = socialLinks.map(({ name, url, ...rest }) => {
   if (name === 'RSS') {
-    return { name, url: getRelativeLocaleUrl(currentLang, url), ...rest }
+    return { name, url: getRelativeLocaleUrl(rssLang, url), ...rest }
   }
 
   if (name === 'Email') {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
+import { getRelativeLocaleUrl } from 'astro:i18n'
 import { themeConfig } from '@/config'
 import { getLangFromPath } from '@/i18n/lang'
-import { getLocalizedPath } from '@/i18n/path'
 
 const { author } = themeConfig.site
 const { links: socialLinks, startYear } = themeConfig.footer
@@ -13,7 +13,7 @@ const year = Number(startYear) === currentYear ? startYear : `${startYear}-${cur
 const currentLang = getLangFromPath(Astro.url.pathname)
 const links = socialLinks.map(({ name, url, ...rest }) => {
   if (name === 'RSS') {
-    return { name, url: getLocalizedPath(url, currentLang), ...rest }
+    return { name, url: getRelativeLocaleUrl(currentLang, url), ...rest }
   }
 
   if (name === 'Email') {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,13 @@
 ---
-import themeConfig from '@/config'
-import { ui } from '@/i18n/ui'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import themeConfig, { defaultLocale } from '@/config'
+import { getUI } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
-const { currentLang, getLocalizedPath, isPost } = getPageInfo(Astro.url.pathname)
+const { currentLang, isPost } = getPageInfo(Astro.url.pathname)
 const { title, subtitle, i18nTitle } = themeConfig.site
 
-const currentUI = ui[currentLang as keyof typeof ui] ?? {}
+const currentUI = getUI(currentLang)
 const headerTitle = i18nTitle ? currentUI.title : title
 const headerSubtitle = i18nTitle ? currentUI.subtitle : subtitle
 
@@ -38,7 +39,7 @@ const SubtitleTag = isPost ? 'div' : 'h2'
     >
       <a
         id="site-title-link"
-        href={getLocalizedPath('/')}
+        href={getRelativeLocaleUrl(currentLang ?? defaultLocale, '/')}
       >
           {headerTitle}
       </a>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,9 +1,11 @@
 ---
-import { ui } from '@/i18n/ui'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import { defaultLocale } from '@/config'
+import { getUI } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
-const { currentLang, isHome, isPost, isTag, isAbout, getLocalizedPath } = getPageInfo(Astro.url.pathname)
-const currentUI = ui[currentLang as keyof typeof ui] ?? {}
+const { currentLang, isHome, isPost, isTag, isAbout } = getPageInfo(Astro.url.pathname)
+const currentUI = getUI(currentLang)
 
 const isPostActive = isHome || isPost
 const isTagActive = isTag
@@ -46,7 +48,7 @@ const navItems = [
     {navItems.map(item => (
       <li>
         <a
-          href={getLocalizedPath(item.href)}
+          href={getRelativeLocaleUrl(currentLang ?? defaultLocale, item.href)}
           class={item.className}
         >
           {item.label}

--- a/src/components/Widgets/TOC.astro
+++ b/src/components/Widgets/TOC.astro
@@ -1,7 +1,7 @@
 ---
 import type { MarkdownHeading } from 'astro'
 import TocIcon from '@/assets/icons/toc-icon.svg'
-import { ui } from '@/i18n/ui'
+import { getUI } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const { currentLang } = getPageInfo(Astro.url.pathname)
-const currentUI = ui[currentLang as keyof typeof ui] ?? {}
+const currentUI = getUI(currentLang)
 
 const { headings = [] } = Astro.props
 const filteredHeadings = headings.filter(heading =>

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,8 @@ export const themeConfig: ThemeConfig = {
     // more languages
     // not fill in the locale code above again, can be an empty array []
     moreLocales: ['en', 'es', 'ja', 'ru', 'zh-tw'], // ['de', 'en', 'es', 'fr', 'ja', 'ko', 'pl', 'pt', 'ru', 'zh', 'zh-tw']
+    // show locale prefix even for default langguage
+    prefixDefaultLocale: false,
     // font styles for post text
     fontStyle: 'sans', // sans, serif
     // date format for posts

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,5 +1,5 @@
 // Global Language Map
-export const langMap: Record<string, string[]> = {
+export const typedLangMap = {
   'de': ['de-DE'],
   'en': ['en-US'],
   'es': ['es-ES'],
@@ -11,7 +11,9 @@ export const langMap: Record<string, string[]> = {
   'ru': ['ru-RU'],
   'zh': ['zh-CN'],
   'zh-tw': ['zh-TW'],
-}
+} as const
+
+export const langMap = typedLangMap as Record<string, readonly string[]>
 
 // Giscus Language Map
 // https://giscus.app/

--- a/src/i18n/lang.ts
+++ b/src/i18n/lang.ts
@@ -1,4 +1,6 @@
-import { allLocales, base, defaultLocale, moreLocales } from '@/config'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import { allLocales, defaultLocale, moreLocales } from '@/config'
+import { normalizePath } from '@/utils/path'
 
 /**
  * Gets the language code from the current path
@@ -7,12 +9,10 @@ import { allLocales, base, defaultLocale, moreLocales } from '@/config'
  * @returns Language code detected from path or default locale
  */
 export function getLangFromPath(path: string) {
-  const pathWithoutBase = base && path.startsWith(base)
-    ? path.slice(base.length)
-    : path
+  const pathWithBase = normalizePath(path, { includeBase: true })
 
   return moreLocales.find(lang =>
-    pathWithoutBase.startsWith(`/${lang}/`)) ?? defaultLocale
+    pathWithBase.startsWith(getRelativeLocaleUrl(lang, ''))) ?? defaultLocale
 }
 
 /**

--- a/src/i18n/lang.ts
+++ b/src/i18n/lang.ts
@@ -1,34 +1,22 @@
 import { getRelativeLocaleUrl } from 'astro:i18n'
-import { allLocales, defaultLocale, moreLocales } from '@/config'
+import themeConfig, { allLocales, defaultLocale, moreLocales } from '@/config'
 import { normalizePath } from '@/utils/path'
 
 /**
  * Gets the language code from the current path
  *
  * @param path Current page path
- * @returns Language code detected from path or default locale
+ * @returns Language code detected from path or default locale or `undefined` if no pattern matches
  */
-export function getLangFromPath(path: string) {
+export function getLangFromPath(path: string): string | undefined {
   const pathWithBase = normalizePath(path, { includeBase: true })
 
-  return moreLocales.find(lang =>
-    pathWithBase.startsWith(getRelativeLocaleUrl(lang, ''))) ?? defaultLocale
-}
-
-/**
- * Get the next language code in the global language cycle
- *
- * @param currentLang Current language code
- * @returns Next language code in the global cycle
- */
-export function getNextGlobalLang(currentLang: string): string {
-  // Get index of current language
-  const currentIndex = allLocales.indexOf(currentLang)
-  if (currentIndex === -1) {
-    return defaultLocale
+  if (themeConfig.global.prefixDefaultLocale) {
+    return allLocales.find(lang =>
+      pathWithBase.startsWith(getRelativeLocaleUrl(lang, '')))
   }
-
-  // Calculate and return next language in cycle
-  const nextIndex = (currentIndex + 1) % allLocales.length
-  return allLocales[nextIndex]
+  else {
+    return moreLocales.find(lang =>
+      pathWithBase.startsWith(getRelativeLocaleUrl(lang, ''))) ?? defaultLocale
+  }
 }

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,4 +1,6 @@
-export const ui = {
+import { defaultLocale } from '@/config'
+
+const ui = {
   'de': {
     title: 'Neusatz',
     subtitle: 'Die Schönheit der Typografie wiederbeleben',
@@ -98,4 +100,13 @@ export const ui = {
     about: '關於',
     toc: '目錄',
   },
+}
+
+export function getUI(lang?: string) {
+  let actualLang = lang ?? defaultLocale
+  if (lang && !Object.keys(ui).includes(lang)) {
+    console.warn(`Requested lang ${lang} is not available in ui, fallback to default`)
+    actualLang = defaultLocale
+  }
+  return ui[actualLang as keyof typeof ui]
 }

--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -2,7 +2,7 @@
 import { ClientRouter } from 'astro:transitions'
 import katexCSS from 'katex/dist/katex.min.css?url'
 import { allLocales, base, defaultLocale, themeConfig } from '@/config'
-import { ui } from '@/i18n/ui'
+import { getUI } from '@/i18n/ui'
 import { getPageInfo } from '@/utils/page'
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
 // Props and Language
 const { postTitle, postDescription, postSlug } = Astro.props
 const { currentLang } = getPageInfo(Astro.url.pathname)
-const currentUI = ui[currentLang as keyof typeof ui] ?? {}
+const currentUI = getUI(currentLang)
 const lang = currentLang === defaultLocale ? '' : `${currentLang}/`
 
 // Site Configuration

--- a/src/pages/[...about].astro
+++ b/src/pages/[...about].astro
@@ -1,7 +1,9 @@
 ---
 import { getCollection, render } from 'astro:content'
-import { defaultLocale, moreLocales } from '@/config'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import { allLocales } from '@/config'
 import Layout from '@/layouts/Layout.astro'
+import { normalizePath } from '@/utils/path'
 
 export async function getStaticPaths() {
   type PathItem = {
@@ -9,23 +11,10 @@ export async function getStaticPaths() {
     props: { lang: string }
   }
 
-  const paths: PathItem[] = []
-
-  // Default locale
-  paths.push({
-    params: { about: 'about/' },
-    props: { lang: defaultLocale },
-  })
-
-  // More locales
-  moreLocales.forEach((lang: string) => {
-    paths.push({
-      params: { about: `${lang}/about/` },
-      props: { lang },
-    })
-  })
-
-  return paths
+  return allLocales.map((lang: string): PathItem => ({
+    params: { about: normalizePath(getRelativeLocaleUrl(lang, 'about')) },
+    props: { lang },
+  }))
 }
 
 const { lang } = Astro.props

--- a/src/pages/[...index].astro
+++ b/src/pages/[...index].astro
@@ -1,8 +1,10 @@
 ---
+import { getRelativeLocaleUrl } from 'astro:i18n'
 import PostList from '@/components/PostList.astro'
-import { defaultLocale, moreLocales } from '@/config'
+import { allLocales } from '@/config'
 import Layout from '@/layouts/Layout.astro'
 import { getPinnedPosts, getPostsByYear } from '@/utils/content'
+import { normalizePath } from '@/utils/path'
 
 export async function getStaticPaths() {
   type PathItem = {
@@ -12,16 +14,10 @@ export async function getStaticPaths() {
 
   const paths: PathItem[] = []
 
-  // Default locale
-  paths.push({
-    params: { index: undefined },
-    props: { lang: defaultLocale },
-  })
-
   // More locales
-  moreLocales.forEach((lang: string) => {
+  allLocales.forEach((lang: string) => {
     paths.push({
-      params: { index: `${lang}/` },
+      params: { index: normalizePath(getRelativeLocaleUrl(lang)) },
       props: { lang },
     })
   })

--- a/src/pages/[...posts_slug].astro
+++ b/src/pages/[...posts_slug].astro
@@ -6,10 +6,12 @@ import PostDate from '@/components/PostDate.astro'
 import TagList from '@/components/TagList.astro'
 import BackButton from '@/components/Widgets/BackButton.astro'
 import TOC from '@/components/Widgets/TOC.astro'
-import { allLocales, defaultLocale, moreLocales } from '@/config'
+import { allLocales } from '@/config'
+import { getPostPath } from '@/i18n/path'
 import Layout from '@/layouts/Layout.astro'
 import { checkPostSlugDuplication } from '@/utils/content'
 import { getPostDescription } from '@/utils/description'
+import { normalizePath } from '@/utils/path'
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts')
@@ -54,33 +56,14 @@ export async function getStaticPaths() {
 
   const paths: PathItem[] = []
 
-  // Default locale
-  posts.forEach((post: CollectionEntry<'posts'>) => {
-    // Show drafts in dev mode only
-    if ((import.meta.env.DEV || !post.data.draft)
-      && (post.data.lang === defaultLocale || post.data.lang === '')) {
-      const slug = post.data.abbrlink || post.id
-
-      paths.push({
-        params: { posts_slug: `posts/${slug}/` },
-        props: {
-          post,
-          lang: defaultLocale,
-          supportedLangs: slugToLangs[slug] ?? [],
-        },
-      })
-    }
-  })
-
-  // More locales
-  moreLocales.forEach((lang: string) => {
+  allLocales.forEach((lang: string) => {
     posts.forEach((post: CollectionEntry<'posts'>) => {
       // Process posts with matching language or no language specified
       if ((import.meta.env.DEV || !post.data.draft)
         && (post.data.lang === lang || post.data.lang === '')) {
         const slug = post.data.abbrlink || post.id
         paths.push({
-          params: { posts_slug: `${lang}/posts/${slug}/` },
+          params: { posts_slug: normalizePath(getPostPath(slug, lang)) },
           props: {
             post,
             lang,

--- a/src/pages/[...tags].astro
+++ b/src/pages/[...tags].astro
@@ -1,8 +1,10 @@
 ---
+import { getRelativeLocaleUrl } from 'astro:i18n'
 import TagList from '@/components/TagList.astro'
-import { defaultLocale, moreLocales } from '@/config'
+import { allLocales } from '@/config'
 import Layout from '@/layouts/Layout.astro'
 import { getAllTags } from '@/utils/content'
+import { normalizePath } from '@/utils/path'
 
 export async function getStaticPaths() {
   type PathItem = {
@@ -10,23 +12,10 @@ export async function getStaticPaths() {
     props: { lang: string }
   }
 
-  const paths: PathItem[] = []
-
-  // Default locale
-  paths.push({
-    params: { tags: 'tags/' },
-    props: { lang: defaultLocale },
-  })
-
-  // More locales
-  moreLocales.forEach((lang: string) => {
-    paths.push({
-      params: { tags: `${lang}/tags/` },
+  return allLocales.map((lang: string): PathItem => ({
+      params: { tags: normalizePath(getRelativeLocaleUrl(lang, 'tags')) },
       props: { lang },
-    })
-  })
-
-  return paths
+  }))
 }
 
 const { lang } = Astro.props

--- a/src/pages/[...tags_tag].astro
+++ b/src/pages/[...tags_tag].astro
@@ -1,9 +1,11 @@
 ---
 import PostList from '@/components/PostList.astro'
 import TagList from '@/components/TagList.astro'
-import { defaultLocale, moreLocales } from '@/config'
+import { allLocales } from '@/config'
+import { getTagPath } from '@/i18n/path'
 import Layout from '@/layouts/Layout.astro'
 import { getAllTags, getPostsByTag, getTagSupportedLangs } from '@/utils/content'
+import { normalizePath } from '@/utils/path'
 
 export async function getStaticPaths() {
   type PathItem = {
@@ -13,21 +15,11 @@ export async function getStaticPaths() {
 
   const paths: PathItem[] = []
 
-  // Default locale
-  const defaultTags = await getAllTags(defaultLocale)
-  defaultTags.forEach((tag: string) => {
-    paths.push({
-      params: { tags_tag: `tags/${tag}/` },
-      props: { tag, lang: defaultLocale },
-    })
-  })
-
-  // More locales
-  for (const lang of moreLocales) {
+  for (const lang of allLocales) {
     const langTags = await getAllTags(lang)
     langTags.forEach((tag: string) => {
       paths.push({
-        params: { tags_tag: `${lang}/tags/${tag}/` },
+        params: { tags_tag: normalizePath(getTagPath(tag, lang)) },
         props: { tag, lang },
       })
     })

--- a/src/pages/[lang]/atom.xml.ts
+++ b/src/pages/[lang]/atom.xml.ts
@@ -1,9 +1,9 @@
 import type { APIContext } from 'astro'
-import { moreLocales } from '@/config'
+import { allLocales } from '@/config'
 import { generateAtom } from '@/utils/feed'
 
 export function getStaticPaths() {
-  return moreLocales.map(lang => ({
+  return allLocales.map(lang => ({
     params: { lang },
   }))
 }

--- a/src/pages/[lang]/rss.xml.ts
+++ b/src/pages/[lang]/rss.xml.ts
@@ -1,9 +1,9 @@
 import type { APIContext } from 'astro'
-import { moreLocales } from '@/config'
+import { allLocales } from '@/config'
 import { generateRSS } from '@/utils/feed'
 
 export function getStaticPaths() {
-  return moreLocales.map(lang => ({
+  return allLocales.map(lang => ({
     params: { lang },
   }))
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { supportedLangs } from '@/i18n/config'
+import type { supportedLangs, typedLangMap } from '@/i18n/config'
 
 type Exclude<T, U> = T extends U ? never : T
 
@@ -29,7 +29,7 @@ export interface ThemeConfig {
     }
   }
   global: {
-    locale: typeof supportedLangs[number]
+    locale: keyof typeof typedLangMap
     moreLocales: typeof supportedLangs[number][]
     prefixDefaultLocale?: boolean
     fontStyle: 'sans' | 'serif'

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -31,6 +31,7 @@ export interface ThemeConfig {
   global: {
     locale: typeof supportedLangs[number]
     moreLocales: typeof supportedLangs[number][]
+    prefixDefaultLocale?: boolean
     fontStyle: 'sans' | 'serif'
     dateFormat: 'YYYY-MM-DD' | 'MM-DD-YYYY' | 'DD-MM-YYYY' | 'MONTH DAY YYYY' | 'DAY MONTH YYYY'
     toc: boolean

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -7,7 +7,7 @@ import MarkdownIt from 'markdown-it'
 import { parse } from 'node-html-parser'
 import sanitizeHtml from 'sanitize-html'
 import { base, defaultLocale, themeConfig } from '@/config'
-import { ui } from '@/i18n/ui'
+import { getUI } from '@/i18n/ui'
 import { memoize } from '@/utils/cache'
 import { getPostDescription } from '@/utils/description'
 
@@ -109,7 +109,7 @@ async function fixRelativeImagePaths(htmlContent: string, baseUrl: string): Prom
  * @returns A Feed instance ready for RSS or Atom output
  */
 export async function generateFeed({ lang }: { lang?: string } = {}) {
-  const currentUI = ui[lang as keyof typeof ui] ?? ui[defaultLocale as keyof typeof ui] ?? {}
+  const currentUI = getUI(lang)
   const siteURL = lang ? `${url}${base}/${lang}/` : `${url}${base}/`
 
   // Create Feed instance

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -1,22 +1,19 @@
-import { base, moreLocales } from '@/config'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import { allLocales } from '@/config'
 import { getLangFromPath } from '@/i18n/lang'
-import { getLocalizedPath } from '@/i18n/path'
+import { normalizePath } from './path'
 
 // Checks if normalized path matches a specific page type
 function isPageType(path: string, prefix: string = '') {
-  const pathWithoutBase = base && path.startsWith(base)
-    ? path.slice(base.length)
-    : path
+  // include base for convenience since `getRelativeLocaleUrl` does have it
+  const pathWithBase = normalizePath(path, { includeBase: true })
 
-  // Removes leading and trailing slashes from the path
-  const normalizedPath = pathWithoutBase.replace(/^\/|\/$/g, '')
-
+  // any url can start with empty prefix, so check them separately
   if (prefix === '') {
-    return normalizedPath === '' || moreLocales.includes(normalizedPath)
+    return allLocales.some(lang => pathWithBase === getRelativeLocaleUrl(lang, prefix))
   }
 
-  return normalizedPath.startsWith(prefix)
-    || moreLocales.some(lang => normalizedPath.startsWith(`${lang}/${prefix}`))
+  return allLocales.some(lang => pathWithBase.startsWith(getRelativeLocaleUrl(lang, prefix)))
 }
 
 export function isHomePage(path: string) {
@@ -50,6 +47,6 @@ export function getPageInfo(path: string) {
     isTag,
     isAbout,
     getLocalizedPath: (targetPath: string) =>
-      getLocalizedPath(targetPath, currentLang),
+      getRelativeLocaleUrl(currentLang, targetPath),
   }
 }

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -46,7 +46,5 @@ export function getPageInfo(path: string) {
     isPost,
     isTag,
     isAbout,
-    getLocalizedPath: (targetPath: string) =>
-      getRelativeLocaleUrl(currentLang, targetPath),
   }
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,59 @@
+/**
+ * Remove all trailing slashes from the given string. Typically, the leading /
+ * will not be removed, i.e. `removeTrailingSlash('/') === '/'`.
+ */
+export function removeTrailingSlash(str: string): string {
+  return str.replace(/(?<=[^/])\/+$/, '')
+}
+
+/**
+ * Normalize the given path (without host) to the required format.
+ * @param path The path that will be normalized
+ * @param ops The normalization options, for default values see below
+ * @param ops.leadingSlash Default is `true`
+ * @param ops.trailingSlash Default is `true`
+ * @param ops.includeBase Default is `false`
+ * @returns Normalized path
+ */
+export function normalizePath(
+  path: string,
+  ops?: {
+    leadingSlash?: boolean
+    trailingSlash?: boolean
+    includeBase?: boolean
+  },
+): string {
+  const { leadingSlash = true, trailingSlash = true, includeBase = false } = ops ?? {}
+
+  // make sure with leading /
+  let result = path.startsWith('/') ? path : `/${path}`
+
+  // must start with /, without trailing /
+  const base = removeTrailingSlash(import.meta.env.BASE_URL)
+  if (base !== '/' && includeBase !== result.startsWith(base)) {
+    if (includeBase) {
+      result = base + result
+    }
+    else {
+      result = result.substring(base.length)
+    }
+  }
+
+  if (leadingSlash !== result.startsWith('/')) {
+    if (leadingSlash) {
+      result = `/${result}`
+    }
+    else {
+      result = result.replace(/^\/+/, '')
+    }
+  }
+  if (trailingSlash !== result.endsWith('/')) {
+    if (trailingSlash) {
+      result = `${result}/`
+    }
+    else {
+      result = removeTrailingSlash(result)
+    }
+  }
+  return result
+}


### PR DESCRIPTION
### Main changes

- Replaced custom locale url constructor with `getRelativeLocaleUrl()`. Note: it already takes the base into account.
- Fixed the type infer of astro config `i18n.locales`, so that the `i18n.fallback` section can be recongnized correctly.

### Motivation

Using custom localized url constructor makes other built-in i18n features unavailable, e.g. [`prefixDefaultLocale=true`](https://docs.astro.build/en/guides/internationalization/#prefixdefaultlocale) or [*fallback*](https://docs.astro.build/en/guides/internationalization/#fallback). Replacing them with built-in API can unblock those features (or with a little extra effort).


### Usage

All changes should have no effect on current (default) hehavior.

If you prefer `prefixDefaultLocale=true`, a placeholder file `pages/index.md` is required, an empty md is enough to make it works.

close #99 