### PR TITLE
Fix RSS feed URL by removing trailing slash in footer links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,7 +13,7 @@ const year = Number(startYear) === currentYear ? startYear : `${startYear}-${cur
 const currentLang = getLangFromPath(Astro.url.pathname)
 const links = socialLinks.map(({ name, url, ...rest }) => {
   if (name === 'RSS') {
-    return { name, url: getLocalizedPath(url, currentLang), ...rest }
+    return { name, url: getLocalizedPath(url, currentLang).slice(0, -1), ...rest }
   }
 
   if (name === 'Email') {


### PR DESCRIPTION
页脚中RSS的链接尾部有一个多余的`/`，导致托管在Cloudflare Pages上的时候点击它会跳转到404页面。
这个pr通过删除链接的最后一个字符来修复。