### PR TITLE
fix: cache function type definition

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -4,10 +4,10 @@
  * @param fn - The async function to memoize
  * @returns Memoized function that caches results
  */
-export function memoize<T>(fn: (...args: any[]) => Promise<T>) {
-  const cache = new Map<string, Promise<T>>()
+export function memoize<F extends (...args: any[]) => Promise<any>>(fn: F): (...args: Parameters<F>) => ReturnType<F> {
+  const cache = new Map<string, ReturnType<F>>()
 
-  return async (...args: any[]): Promise<T> => {
+  return (...args: Parameters<F>): ReturnType<F> => {
     // Generate cache key from function arguments
     const key = JSON.stringify(args)
 
@@ -17,7 +17,7 @@ export function memoize<T>(fn: (...args: any[]) => Promise<T>) {
     }
 
     // Execute the original function and cache the promise
-    const promise = fn(...args)
+    const promise = fn(...args) as ReturnType<F>
     cache.set(key, promise)
 
     // Remove failed promises from cache to allow retry


### PR DESCRIPTION
In the current implementation, `memoize` generalizes the paramaters into `any[]` which is bad and distrubs the IDE & ts type checking.

The fix makes sure the cachelized fucntion has exactly same signature (param list and return value).

### Preview

**Before**

<img width="768" height="266" alt="image" src="https://github.com/user-attachments/assets/b0282f4a-7b18-428f-aeb5-6584c38e8d7a" />


**Afetr**

<img width="779" height="236" alt="image" src="https://github.com/user-attachments/assets/3a02cc1b-b6ce-442c-99bb-01f83ab6e8be" />
